### PR TITLE
fixed main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import "github.com/kataras/iris/v12"
 func main() {
 	app := newApp()
 
-	app.Listen("8080")
+	app.Listen(":8080")
 }
 
 func newApp() *iris.Application {


### PR DESCRIPTION
missing colon cause this error :
[ERRO] 2022/11/17 20:14 listen tcp: address 8080: missing port in address

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/iris-contrib/basic-template/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/iris-contrib/basic-template/issues) link which your PR solves otherwise your work may be rejected.